### PR TITLE
fix: define default route - redirect to /resources

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  redirects: async () => [
+    {
+      source: "/",
+      destination: "/resources",
+      permanent: true,
+    },
+  ],
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
The default route is undefined and displays an error.
This redirect definition will auto redirect from the route `/` to the route `/resources`

### Before localhost:3000
<img width="1021" alt="image" src="https://github.com/FillUsIn/PalestineHub/assets/6170289/2270b2a3-5f7c-489c-8513-1165d84c191e">

### After localhost:3000
Redirects to /resources
<img width="1185" alt="image" src="https://github.com/FillUsIn/PalestineHub/assets/6170289/8b222b23-8562-4a30-93bb-89243f29e083">

