### PR TITLE
fix: import global css to storybook preview

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import '@mantine/core/styles.css';
+import '../src/styles/globals.css';
 
 import React, { useEffect } from 'react';
 import { addons } from '@storybook/preview-api';


### PR DESCRIPTION
Minor fix to correctly display layout in the storybook preview window